### PR TITLE
use 204 instead of 404 if chunk does not exist

### DIFF
--- a/admin_async_upload/views.py
+++ b/admin_async_upload/views.py
@@ -30,7 +30,7 @@ class UploadView(View):
     def get(self, request, *args, **kwargs):
         r = ResumableFile(self.model_upload_field, user=request.user, params=request.GET)
         if not r.chunk_exists:
-            return HttpResponse('chunk not found', status=404)
+            return HttpResponse('chunk not found', status=204)
         if r.is_complete:
             return HttpResponse(r.collect())
         return HttpResponse('chunk exists')


### PR DESCRIPTION
sending 404 is considered an error in many layers of the stack.
using http status code 304 avoids those warnings/errors in the  django backend and browser.
204 is the recommended response code according to https://github.com/23/resumable.js