### PR TITLE
Replaced deprecated/removed method ugettext_lazy with gettext_lazy.

### DIFF
--- a/admin_async_upload/storage.py
+++ b/admin_async_upload/storage.py
@@ -4,7 +4,7 @@ import posixpath
 from django.core.files.storage import get_storage_class
 
 from django.conf import settings
-from django.utils.encoding import force_text, force_str
+from django.utils.encoding import force_str
 
 
 class ResumableStorage(object):
@@ -41,6 +41,6 @@ class ResumableStorage(object):
         return storage_class(*args, **kwargs)
 
     def full_filename(self, filename, upload_to):
-        dirname = force_text(datetime.datetime.now().strftime(force_str(upload_to)))
+        dirname = force_str(datetime.datetime.now().strftime(force_str(upload_to)))
         filename = posixpath.join(dirname, filename)
         return self.get_persistent_storage().generate_filename(filename)

--- a/admin_async_upload/widgets.py
+++ b/admin_async_upload/widgets.py
@@ -5,14 +5,14 @@ from django.forms import FileInput, CheckboxInput, forms
 from django.template import loader
 from django.templatetags.static import static
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from admin_async_upload.storage import ResumableStorage
 
 
 class ResumableBaseWidget(FileInput):
     template_name = 'admin_resumable/admin_file_input.html'
-    clear_checkbox_label = ugettext_lazy('Clear')
+    clear_checkbox_label = gettext_lazy('Clear')
 
     def render(self, name, value, attrs=None, **kwargs):
         persistent_storage = ResumableStorage().get_persistent_storage()


### PR DESCRIPTION
Needed to compile with Python 3.8.10 and higher.